### PR TITLE
add outputJson option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -242,3 +242,4 @@ assumptions without needing to alter the core files.
  4. debug: Show additional debug messages. Default is false.
  5. debugHarvest: Enable debugging for the Harvest API module. Default is false.
  6. skipEmpty: Removes entries with total time 0 from the output. Default is false.
+ 7. outputJson: Returns a json array instead of the default format. Default is false.

--- a/src/summary.coffee
+++ b/src/summary.coffee
@@ -92,14 +92,21 @@ insertEntry = (entry) ->
     entries[client].projects[project].tasks[task].total += time
     entries[client].projects[project].tasks[task].notes[note].total += time
 
+# Filters out all entries that has 0 hours if the skipEmpty config is set
+filterEntries = (entries) ->
+    entries.filter (entry) -> !(config.skipEmpty && entry.hours == 0)
 
 # Callback to parse data from Harvest and synchronise multiple callouts
 parseData = (err, tasks) ->
     logger.error err if err?
-    if tasks.day_entries
-        for task in tasks.day_entries
-            insertEntry task
-    syncParsing()
+    
+    if !config.outputJson
+        if tasks.day_entries
+            for task in tasks.day_entries
+                insertEntry task
+        syncParsing()
+    else if tasks.day_entries
+        console.log(JSON.stringify filterEntries tasks.day_entries)
 
 
 # Dummy callback to prevent duplicating parsing


### PR DESCRIPTION
This is created in reponse to #23 .
I have not been doing coffeescript in a long time so more than open to feedback and suggestions.
Maybe the "fork" from the standard output should not reside in the `parseData` function ?

Thanks for a cool, solid cli app that still runs 4 years after creation 👍 